### PR TITLE
Fix bug with network policy

### DIFF
--- a/charts/wiredoor-gateway/templates/network-policy.yaml
+++ b/charts/wiredoor-gateway/templates/network-policy.yaml
@@ -33,6 +33,6 @@ spec:
             - 172.16.0.0/20
       {{- end }}
       {{- with .Values.networkPolicy.egress }}
-      {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes a bug where network policy cannot render egress rules

# 🚀 Pull Request

## Summary

The ndent was off which would cause a parsing error when rendering the template with egress rules specified in the vaules.

---

## Checklist

- [ ] Code compiles and runs correctly
- [ ] Linting and formatting pass
- [ ] Tests have been added/updated (if applicable)
- [ ] Docs have been updated (if applicable)
