### PR TITLE
fix: remove duplicate instance label

### DIFF
--- a/charts/wiredoor-gateway/templates/_helpers.tpl
+++ b/charts/wiredoor-gateway/templates/_helpers.tpl
@@ -35,7 +35,6 @@ Common labels
 */}}
 {{- define "wiredoor-gateway.labels" -}}
 helm.sh/chart: {{ include "wiredoor-gateway.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/part-of: wiredoor
 {{ include "wiredoor-gateway.selectorLabels" . }}
 {{- if .Chart.AppVersion }}


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

Removes the duplicate instance label definition from the Helm template

---

## Related Issues

Closes #3 

---

## Checklist

- [x] Code compiles and runs correctly
- [ ] Linting and formatting pass
- [ ] Tests have been added/updated (if applicable)
- [ ] Docs have been updated (if applicable)
