### PR TITLE
feat: add support for existing secret in wiredoor configuration

### DIFF
--- a/charts/wiredoor-gateway/templates/deployment.yaml
+++ b/charts/wiredoor-gateway/templates/deployment.yaml
@@ -12,7 +12,9 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if or .Values.wiredoor.server .Values.wiredoor.token }}
+        {{- if .Values.wiredoor.existingSecret }}
+        checksum/wiredoor-secrets: "{{ .Values.wiredoor.existingSecret | sha256sum }}"
+        {{- else if or .Values.wiredoor.server .Values.wiredoor.token }}
         checksum/wiredoor-secrets: "{{ toJson .Values.wiredoor | sha256sum }}"
         {{- end }}
         {{- if .Values.podAnnotations }}
@@ -36,10 +38,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.wiredoor.server .Values.wiredoor.token }}
+          {{- if or .Values.wiredoor.existingSecret (or .Values.wiredoor.server .Values.wiredoor.token) }}
           envFrom:
             - secretRef:
-                name: "wiredoor-secrets"
+                name: {{ .Values.wiredoor.existingSecret | default "wiredoor-secrets" | quote }}
           {{- end }}
           {{- if and .Values.service .Values.service.port }}
           ports:

--- a/charts/wiredoor-gateway/values.yaml
+++ b/charts/wiredoor-gateway/values.yaml
@@ -15,8 +15,10 @@ nameOverride: ""
 fullnameOverride: ""
 
 wiredoor:
-  server: 
-  token: 
+  # existingSecret: name of an existing Secret to use for WIREDOOR_URL and TOKEN. When set, server/token are ignored.
+  existingSecret: ""
+  server:
+  token:
   ip: 
 
 podAnnotations: {}


### PR DESCRIPTION
Resolves https://github.com/wiredoor/charts/issues/5

- Introduced `existingSecret` option in values.yaml
- Updated deployment.yaml to use the existing Secret or fallback to server/token values

## Testing
Confirmed via helm template still uses the server/token values when specified
```
helm template test ../wiredoor-charts/charts/charts/wiredoor-gateway --set wiredoor.server=https://test.com --set wiredoor.token=testtoken
---
# Source: wiredoor-gateway/templates/secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: wiredoor-secrets
data:
  WIREDOOR_URL: "aHR0cHM6Ly90ZXN0LmNvbQ=="
  TOKEN: "dGVzdHRva2Vu"
---
# Source: wiredoor-gateway/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-wiredoor-gateway
  labels:
    helm.sh/chart: wiredoor-gateway-1.0.1
    app.kubernetes.io/part-of: wiredoor
    app.kubernetes.io/name: wiredoor-gateway
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "1.1.2"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: wiredoor-gateway
      app.kubernetes.io/instance: test
  template:
    metadata:
      annotations:
        checksum/wiredoor-secrets: "c616da549b55f4fb5077272d65d67b253096c87de6bd3cfe1774236a87c3d2e1"
      labels:
        helm.sh/chart: wiredoor-gateway-1.0.1
        app.kubernetes.io/part-of: wiredoor
        app.kubernetes.io/name: wiredoor-gateway
        app.kubernetes.io/instance: test
        app.kubernetes.io/version: "1.1.2"
        app.kubernetes.io/managed-by: Helm
    spec:
      securityContext:
        {}
      containers:
        - name: wiredoor-gateway
          securityContext:
            capabilities:
              add:
              - NET_ADMIN
          image: "wiredoor/wiredoor-cli:v1.1.2"
          imagePullPolicy: IfNotPresent
          envFrom:
            - secretRef:
                name: "wiredoor-secrets"
          livenessProbe:
            exec:
              command:
              - sh
              - -c
              - /usr/bin/wiredoor status --health
            initialDelaySeconds: 15
            periodSeconds: 10
            timeoutSeconds: 1
          readinessProbe:
            exec:
              command:
              - sh
              - -c
              - /usr/bin/wiredoor status --health
            initialDelaySeconds: 15
            periodSeconds: 10
            timeoutSeconds: 1
          resources:
            limits:
              cpu: 100m
              memory: 128Mi
            requests:
              cpu: 100m
              memory: 128Mi
```

Confirmed via helm template `envFrom` uses the new `existingSecret`
```
helm template test ../wiredoor-charts/charts/charts/wiredoor-gateway --set wiredoor.existingSecret=testSecret
---
# Source: wiredoor-gateway/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-wiredoor-gateway
  labels:
    helm.sh/chart: wiredoor-gateway-1.0.1
    app.kubernetes.io/part-of: wiredoor
    app.kubernetes.io/name: wiredoor-gateway
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "1.1.2"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: wiredoor-gateway
      app.kubernetes.io/instance: test
  template:
    metadata:
      annotations:
        checksum/wiredoor-secrets: "36f0f4b6056ac4d0a4b7dbb7c94597c1d44c9d6c84dc370121deedbde5049560"
      labels:
        helm.sh/chart: wiredoor-gateway-1.0.1
        app.kubernetes.io/part-of: wiredoor
        app.kubernetes.io/name: wiredoor-gateway
        app.kubernetes.io/instance: test
        app.kubernetes.io/version: "1.1.2"
        app.kubernetes.io/managed-by: Helm
    spec:
      securityContext:
        {}
      containers:
        - name: wiredoor-gateway
          securityContext:
            capabilities:
              add:
              - NET_ADMIN
          image: "wiredoor/wiredoor-cli:v1.1.2"
          imagePullPolicy: IfNotPresent
          envFrom:
            - secretRef:
                name: "testSecret"
          livenessProbe:
            exec:
              command:
              - sh
              - -c
              - /usr/bin/wiredoor status --health
            initialDelaySeconds: 15
            periodSeconds: 10
            timeoutSeconds: 1
          readinessProbe:
            exec:
              command:
              - sh
              - -c
              - /usr/bin/wiredoor status --health
            initialDelaySeconds: 15
            periodSeconds: 10
            timeoutSeconds: 1
          resources:
            limits:
              cpu: 100m
              memory: 128Mi
            requests:
              cpu: 100m
              memory: 128Mi
```
